### PR TITLE
Fix some changelog link sloppiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.0.3]
-* Misc minimal fixes to get the gem building and releasable
-  [#2](https://github.com/doximity/rake-ui/pull/3)
+* Misc minimal fixes to get the gem building and releasable according to our open source standards
+  [#3](https://github.com/doximity/simplekiq/pull/3)
 * Copy over library code from prior sources with maintained history
-  [#1](https://github.com/doximity/simplekiq/pull/1)
+  [#2](https://github.com/doximity/simplekiq/pull/2)
 
 ## [0.0.2]
 * Scrubbed version from rubygems, do not use


### PR DESCRIPTION
Pretty straightforward, served up some bad copypasta in the CHANGELOG and this fixes it.