### PR TITLE
Allow higher Sidekiq versions in gemspec

### DIFF
--- a/simplekiq.gemspec
+++ b/simplekiq.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "standard"
 
-  spec.add_dependency "sidekiq", "~> 5.2.9"
+  spec.add_dependency "sidekiq", ">= 5.2.9"
 
   # Can't define this explicitly because it would be inappropriate to vendor this
   # pay-to-use library into the gem and it is not available on rubygems and


### PR DESCRIPTION
When I tried to install Simplekiq on a project, I had an issue with resolving dependencies:

```
Resolving dependencies....
Bundler could not find compatible versions for gem "sidekiq":
  In snapshot (Gemfile.lock):
    sidekiq (= 6.3.1)

  In Gemfile:
    sidekiq-pro was resolved to 5.3.0, which depends on
      sidekiq (>= 6.3.0)

    simplekiq was resolved to 0.0.3, which depends on
      sidekiq (~> 5.2.9)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

The README says "ensure you have sidekiq-pro at version ~> 5.0.0 or higher", so I'm assuming that newer versions of Sidekiq are also supported. Is that right?

I saw #12 mentions being blocked on getting sidekiq-pro as a dependency, so no worries if this needs to wait or is changing shortly!