### PR TITLE
AT-172 Add toplevel batch to orchestrations

### DIFF
--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -11,4 +11,18 @@ require "simplekiq/orchestration_job"
 require "simplekiq/batching_job"
 
 module Simplekiq
+  class << self
+    # Empty batches with no jobs will never invoke callbacks, so handle
+    # that case by immediately manually invoking :complete & :success.
+    def run_empty_callbacks(job, args:)
+      job.on_complete(nil, {"args" => args}) if job.respond_to?(:on_complete)
+      job.on_success(nil, {"args" => args}) if job.respond_to?(:on_success)
+    end
+
+    def auto_define_callbacks(batch, args:, job:)
+      batch.on("death", job.class, "args" => args) if job.respond_to?(:on_death)
+      batch.on("complete", job.class, "args" => args) if job.respond_to?(:on_complete)
+      batch.on("success", job.class, "args" => args) if job.respond_to?(:on_success)
+    end
+  end
 end

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -21,10 +21,6 @@ module Simplekiq
       serial_workflow
     end
 
-    def execute(parent_batch)
-      OrchestrationExecutor.execute(workflow: serialized_workflow, parent_batch: parent_batch)
-    end
-
     def serialized_workflow
       @serialized_workflow ||= serial_workflow.map do |step|
         case step[0]

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -25,7 +25,7 @@ module Simplekiq
         step_batch.on(
           "success",
           self.class,
-          { "orchestration_workflow" => workflow, "step" => step + 1 }
+          {"orchestration_workflow" => workflow, "step" => step + 1}
         )
 
         step_batch.jobs do

--- a/lib/simplekiq/orchestration_job.rb
+++ b/lib/simplekiq/orchestration_job.rb
@@ -11,7 +11,14 @@ module Simplekiq
 
     def perform(*args)
       perform_orchestration(*args)
-      orchestration.execute(batch)
+
+      # This makes it so that if there is a parent batch which this orchestration is run under, then the layered batches will be:
+      # parent_batch( orchestration_batch( batch_of_first_step_of_the_orchestration ) )
+      # If there is no parent batch, then it will simply be:
+      # orchestration_batch( batch_of_first_step_of_the_orchestration )
+      conditionally_within_parent_batch do
+        OrchestrationExecutor.execute(classname: self.class.name, workflow: orchestration.serialized_workflow)
+      end
     end
 
     def workflow_plan(*args)
@@ -20,6 +27,16 @@ module Simplekiq
     end
 
     private
+
+    def conditionally_within_parent_batch
+      if batch
+        batch.jobs do
+          yield
+        end
+      else
+        yield
+      end
+    end
 
     def orchestration
       @orchestration ||= Orchestration.new

--- a/lib/simplekiq/orchestration_job.rb
+++ b/lib/simplekiq/orchestration_job.rb
@@ -17,7 +17,7 @@ module Simplekiq
       # If there is no parent batch, then it will simply be:
       # orchestration_batch( batch_of_first_step_of_the_orchestration )
       conditionally_within_parent_batch do
-        OrchestrationExecutor.execute(classname: self.class.name, workflow: orchestration.serialized_workflow)
+        OrchestrationExecutor.execute(args: args, job: self, workflow: orchestration.serialized_workflow)
       end
     end
 

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Simplekiq::OrchestrationExecutor do
+  let(:workflow) do
+    [
+      {"klass" => "OrcTest::JobA", "args" => [1]}
+    ]
+  end
+
+  let(:classname) { "FakeOrchestration" }
+
+  describe ".execute" do
+    def execute
+      described_class.execute(classname: classname, workflow: workflow)
+    end
+
+    it "kicks off the first step within a new batch" do
+      batch_double = instance_double(Sidekiq::Batch)
+
+      batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
+      allow(batch_double).to receive(:jobs) do |&block|
+        batch_stack_depth+= 1
+        block.call
+        batch_stack_depth-= 1
+      end
+
+      allow(Sidekiq::Batch).to receive(:new).and_return(batch_double)
+
+      called_yet = false
+      allow_any_instance_of(Simplekiq::OrchestrationExecutor).to receive(:run_step) do |_receiver, orchestration_batch, workflow, step|
+        called_yet = true
+        expect(batch_stack_depth).to eq 1
+
+        expect(orchestration_batch).to eq batch_double
+        expect(workflow).to eq workflow
+        expect(step).to eq 0
+      end
+
+      expect(batch_double).to receive(:description=).with("FakeOrchestration Simplekiq orchestration")
+
+      expect { execute }.to change { called_yet }.to(true)
+    end
+  end
+end

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
 
       batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
       allow(batch_double).to receive(:jobs) do |&block|
-        batch_stack_depth+= 1
+        batch_stack_depth += 1
         block.call
-        batch_stack_depth-= 1
+        batch_stack_depth -= 1
       end
 
       allow(Sidekiq::Batch).to receive(:new).and_return(batch_double)

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -7,38 +7,87 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
     ]
   end
 
-  let(:classname) { "FakeOrchestration" }
+  let!(:job) do
+    stub_const("FakeOrchestration", Class.new do
+      def on_success(status, options)
+      end
+    end)
+
+    FakeOrchestration.new
+  end
+
+  before { stub_const("OrcTest::JobA", Class.new) }
 
   describe ".execute" do
     def execute
-      described_class.execute(classname: classname, workflow: workflow)
+      described_class.execute(args: ["some", "args"], job: job, workflow: workflow)
     end
 
-    it "kicks off the first step within a new batch" do
+    it "kicks off the first step with a new batch" do
       batch_double = instance_double(Sidekiq::Batch)
-
-      batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
-      allow(batch_double).to receive(:jobs) do |&block|
-        batch_stack_depth += 1
-        block.call
-        batch_stack_depth -= 1
-      end
-
       allow(Sidekiq::Batch).to receive(:new).and_return(batch_double)
+      expect(batch_double).to receive(:description=).with("FakeOrchestration Simplekiq orchestration")
+      expect(batch_double).to receive(:on).with("success", FakeOrchestration, "args" => ["some", "args"])
 
-      called_yet = false
-      allow_any_instance_of(Simplekiq::OrchestrationExecutor).to receive(:run_step) do |_receiver, orchestration_batch, workflow, step|
-        called_yet = true
-        expect(batch_stack_depth).to eq 1
+      instance = instance_double(Simplekiq::OrchestrationExecutor)
+      allow(Simplekiq::OrchestrationExecutor).to receive(:new).and_return(instance)
+      expect(instance).to receive(:run_step).with(batch_double, workflow, 0)
 
-        expect(orchestration_batch).to eq batch_double
-        expect(workflow).to eq workflow
-        expect(step).to eq 0
+      execute
+    end
+
+    context "when the workflow is empty" do
+      let(:workflow) { [] }
+
+      it "immediately calls the orchestration callbacks" do
+        expect(job).to receive(:on_success).with(nil, "args" => ["some", "args"])
+
+        execute
       end
 
-      expect(batch_double).to receive(:description=).with("FakeOrchestration Simplekiq orchestration")
+      it "doesn't create new batches or run any steps" do
+        expect(Sidekiq::Batch).not_to receive(:new)
+        expect(described_class).not_to receive(:new)
 
-      expect { execute }.to change { called_yet }.to(true)
+        execute
+      end
+    end
+  end
+
+  describe "run_step" do
+    let(:orchestration_batch) { instance_double(Sidekiq::Batch) }
+    let(:step_batch) { instance_double(Sidekiq::Batch) }
+    let(:step) { 0 }
+    let(:instance) { described_class.new }
+
+    it "runs the next job within a new step batch which is within the orchestration batch" do
+      batch_stack = [] # to keep track of how deeply nested within batches we are
+      expect(orchestration_batch).to receive(:jobs) do |&block|
+        expect(batch_stack).to be_empty
+
+        batch_stack.push("orchestration")
+        block.call
+        batch_stack.shift
+      end
+      expect(step_batch).to receive(:jobs) do |&block|
+        expect(batch_stack).to eq ["orchestration"]
+        batch_stack.push("step")
+        block.call
+        batch_stack.shift
+      end
+
+      expect(OrcTest::JobA).to receive(:perform_async) do |arg|
+        expect(batch_stack).to eq ["orchestration", "step"]
+        expect(arg).to eq 1
+      end
+
+      allow(Sidekiq::Batch).to receive(:new).and_return(step_batch)
+      expect(step_batch).to receive(:on).with("success", described_class, {
+        "orchestration_workflow" => workflow,
+        "step" => 1
+      })
+
+      instance.run_step(orchestration_batch, workflow, 0)
     end
   end
 end

--- a/spec/orchestration_job_spec.rb
+++ b/spec/orchestration_job_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Simplekiq::OrchestrationJob do
 
     batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
     allow(batch_double).to receive(:jobs) do |&block|
-      batch_stack_depth+= 1
+      batch_stack_depth += 1
       block.call
-      batch_stack_depth-= 1
+      batch_stack_depth -= 1
     end
 
     stub_const("FakeOrchestration", Class.new do

--- a/spec/orchestration_spec.rb
+++ b/spec/orchestration_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Simplekiq::Orchestration do
+  let(:orchestration) { described_class.new }
+
+  before do
+    stub_const("OrcTest::JobA", Class.new)
+    stub_const("OrcTest::JobB", Class.new)
+  end
+
+  describe "in_parallel" do
+    subject { orchestration.serialized_workflow }
+
+    context "when in_parallel is called without any run steps" do
+      before do
+        orchestration.in_parallel do
+          # nothing
+        end
+      end
+
+      it "does not add a step" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when in_parallel is called with run steps" do
+      before do
+        orchestration.in_parallel do
+          orchestration.run OrcTest::JobA, "syn"
+          orchestration.run OrcTest::JobB, "ack"
+        end
+      end
+
+
+      it "adds a step" do
+        expect(subject).to eq [
+          [
+            {"klass" => "OrcTest::JobA", "args" => ["syn"]},
+            {"klass" => "OrcTest::JobB", "args" => ["ack"]}
+          ]
+        ]
+      end
+    end
+  end
+end

--- a/spec/orchestration_spec.rb
+++ b/spec/orchestration_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Simplekiq::Orchestration do
         end
       end
 
-
       it "adds a step" do
         expect(subject).to eq [
           [

--- a/spec/simplekiq_spec.rb
+++ b/spec/simplekiq_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe Simplekiq do
     end
 
     it "defines callbacks on the batch for every callback the job defines" do
-      expect(batch).to receive(:on).once.ordered.with("death", OrcTest::CallbacksJob, "args" => [1,2,3])
-      expect(batch).to receive(:on).once.ordered.with("complete", OrcTest::CallbacksJob, "args" => [1,2,3])
-      expect(batch).to receive(:on).once.ordered.with("success", OrcTest::CallbacksJob, "args" => [1,2,3])
+      expect(batch).to receive(:on).once.ordered.with("death", OrcTest::CallbacksJob, "args" => [1, 2, 3])
+      expect(batch).to receive(:on).once.ordered.with("complete", OrcTest::CallbacksJob, "args" => [1, 2, 3])
+      expect(batch).to receive(:on).once.ordered.with("success", OrcTest::CallbacksJob, "args" => [1, 2, 3])
       call
     end
 

--- a/spec/simplekiq_spec.rb
+++ b/spec/simplekiq_spec.rb
@@ -1,7 +1,83 @@
 # frozen_string_literal: true
 
 RSpec.describe Simplekiq do
+  before do
+    stub_const("OrcTest::BasicJob", Class.new)
+
+    stub_const("OrcTest::CallbacksJob", Class.new do
+      def on_complete(status, options)
+      end
+
+      def on_success(status, options)
+      end
+
+      def on_death(status, options)
+      end
+    end)
+  end
+
   it "has a version number" do
     expect(Simplekiq::VERSION).not_to be nil
+  end
+
+  describe ".run_empty_callbacks" do
+    let(:args) { [1, 2, 3] }
+    let(:job) { OrcTest::CallbacksJob.new }
+
+    def call
+      Simplekiq.run_empty_callbacks(job, args: args)
+    end
+
+    it "calls the on_success and on_complete callback methods on the job" do
+      expect(job).to receive(:on_complete).with(nil, "args" => [1, 2, 3])
+      expect(job).to receive(:on_success).with(nil, "args" => [1, 2, 3])
+      call
+    end
+
+    it "does not call on_death" do
+      expect(job).not_to receive(:on_death)
+      call
+    end
+
+    context "when the job does not define the callback methods" do
+      let(:job) { OrcTest::BasicJob.new }
+
+      it "does not call any callbacks" do
+        # This approach ends up making the object appear to `respond_to?` each method because of the spy rspec adds
+        # expect(job).not_to receive(:on_complete)
+        # expect(job).not_to receive(:on_success)
+        # expect(job).not_to receive(:on_death)
+
+        # so instead, just:
+        expect { call }.not_to raise_error
+        # since it'd raise a NoMethodError if it tried to call them for this class
+      end
+    end
+  end
+
+  describe ".auto_define_callbacks" do
+    let(:batch) { instance_double(Sidekiq::Batch) }
+    let(:args) { [1, 2, 3] }
+    let(:job) { OrcTest::CallbacksJob.new }
+
+    def call
+      Simplekiq.auto_define_callbacks(batch, args: args, job: job)
+    end
+
+    it "defines callbacks on the batch for every callback the job defines" do
+      expect(batch).to receive(:on).once.ordered.with("death", OrcTest::CallbacksJob, "args" => [1,2,3])
+      expect(batch).to receive(:on).once.ordered.with("complete", OrcTest::CallbacksJob, "args" => [1,2,3])
+      expect(batch).to receive(:on).once.ordered.with("success", OrcTest::CallbacksJob, "args" => [1,2,3])
+      call
+    end
+
+    context "when the job does not define the callback methods" do
+      let(:job) { OrcTest::BasicJob.new }
+
+      it "does not define any callbacks" do
+        expect(batch).not_to receive(:on)
+        call
+      end
+    end
   end
 end


### PR DESCRIPTION
[JIRA - Simplekiq orchestration failure handling](https://doximity.atlassian.net/browse/AT-172?atlOrigin=eyJpIjoiYzExYWRjMzQwMDBmNGQ3Nzk1NzJhNTllYjg5YTZlOGEiLCJwIjoiaiJ9)

* Orchestrations now have on_death, on_complete, and on_success support (although on_success is pointless since the last job in the orchestration is behaviorally identical, but might as well for consistency)
* Empty orchestrations will automatically call the appropriate (success + complete) callbacks even though there's no batches, just like BatchingJob
* Extracted and shared the callback definition support between BatchingJob and OrchestrationJob as well as the call-success-and-complete-on-empty thing
* Misc cleanup, renaming, etc, as I worked my way through restructuring things