### PR TITLE
AT-172 Fix empty toplevel batch bug and add step batch description

### DIFF
--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -7,6 +7,7 @@ require "simplekiq/orchestration_executor"
 require "simplekiq/orchestration"
 require "simplekiq/orchestration_job"
 require "simplekiq/batching_job"
+require "simplekiq/batch_tracker_job"
 
 module Simplekiq
   class << self

--- a/lib/simplekiq/batch_tracker_job.rb
+++ b/lib/simplekiq/batch_tracker_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This job serves two purposes:
+# * TODO: It provides a convenient way to track top-level orchestration batches
+# * The top-level orchestration batch would otherwise be empty (aside from
+#   child-batches) and all sidekiq-pro batches must have at least 1 job
+
+module Simplekiq
+  class BatchTrackerJob
+    include Sidekiq::Worker
+
+    def perform(klass_name, bid, args)
+      # In the future, this will likely surface the toplevel batch to a callback method on the
+      # orchestration job. We're holding off on this until we have time to design a comprehensive
+      # plan for providing simplekiq-wide instrumentation, ideally while being backwards compatible
+      # for in-flight orchestrations.
+
+      # For now, it's just satisfying the all-batches-must-have-jobs limitation in sidekiq-pro
+      # described at the head of the file.
+    end
+  end
+end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -14,30 +14,28 @@ module Simplekiq
 
       orchestration_batch.jobs do
         Simplekiq::BatchTrackerJob.perform_async(job.class.name, orchestration_batch.bid, args)
-      end
 
-      new.run_step(orchestration_batch, workflow, 0)
+        new.run_step(workflow, 0)
+      end
     end
 
-    def run_step(orchestration_batch, workflow, step)
+    def run_step(workflow, step)
       *jobs = workflow.at(step)
       # This will never be empty because Orchestration#serialized_workflow skips inserting
       # a new step for in_parallel if there were no inner jobs specified.
 
       next_step = step + 1
-      orchestration_batch.jobs do
-        step_batch = Sidekiq::Batch.new
-        step_batch.description = "Simplekiq orchestrated step #{next_step}"
-        step_batch.on(
-          "success",
-          self.class,
-          {"orchestration_workflow" => workflow, "step" => next_step}
-        )
+      step_batch = Sidekiq::Batch.new
+      step_batch.description = "Simplekiq orchestrated step #{next_step}"
+      step_batch.on(
+        "success",
+        self.class,
+        {"orchestration_workflow" => workflow, "step" => next_step}
+      )
 
-        step_batch.jobs do
-          jobs.each do |job|
-            Object.const_get(job["klass"]).perform_async(*job["args"])
-          end
+      step_batch.jobs do
+        jobs.each do |job|
+          Object.const_get(job["klass"]).perform_async(*job["args"])
         end
       end
     end
@@ -45,8 +43,9 @@ module Simplekiq
     def on_success(status, options)
       return if options["step"] == options["orchestration_workflow"].length
 
-      orchestration_batch = Sidekiq::Batch.new(status.parent_bid)
-      run_step(orchestration_batch, options["orchestration_workflow"], options["step"])
+      Sidekiq::Batch.new(status.parent_bid).jobs do
+        run_step(options["orchestration_workflow"], options["step"])
+      end
     end
   end
 end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -12,6 +12,10 @@ module Simplekiq
       orchestration_batch.description = "#{job.class.name} Simplekiq orchestration"
       Simplekiq.auto_define_callbacks(orchestration_batch, args: args, job: job)
 
+      orchestration_batch.jobs do
+        Simplekiq::BatchTrackerJob.perform_async(job.class.name, orchestration_batch.bid, args)
+      end
+
       new.run_step(orchestration_batch, workflow, 0)
     end
 
@@ -20,12 +24,14 @@ module Simplekiq
       # This will never be empty because Orchestration#serialized_workflow skips inserting
       # a new step for in_parallel if there were no inner jobs specified.
 
+      next_step = step + 1
       orchestration_batch.jobs do
         step_batch = Sidekiq::Batch.new
+        step_batch.description = "Simplekiq orchestrated step #{next_step}"
         step_batch.on(
           "success",
           self.class,
-          {"orchestration_workflow" => workflow, "step" => step + 1}
+          {"orchestration_workflow" => workflow, "step" => next_step}
         )
 
         step_batch.jobs do

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
 
       batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
       expect(batch_double).to receive(:jobs) do |&block|
-        batch_stack_depth+= 1
+        batch_stack_depth += 1
         block.call
-        batch_stack_depth-= 1
+        batch_stack_depth -= 1
       end
 
       expect(Simplekiq::BatchTrackerJob).to receive(:perform_async) do
@@ -76,9 +76,9 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
     it "runs the next job within a new step batch" do
       batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
       expect(step_batch).to receive(:jobs) do |&block|
-        batch_stack_depth+= 1
+        batch_stack_depth += 1
         block.call
-        batch_stack_depth-= 1
+        batch_stack_depth -= 1
       end
 
       expect(OrcTest::JobA).to receive(:perform_async) do |arg|


### PR DESCRIPTION
Fixes a bug from - https://github.com/doximity/simplekiq/pull/21

Turns out batches can't be job-less even if they have child batches. This adds an empty job just to fix that which although slightly kludgey is a simple and reliable solution which makes everything Just Work. Also gives us an opportunity for toplevel tracking should we need it in the future. I've added some inline notes about how that tracking might work and why it isn't there yet.

Nutshell - we don't want to add and remove it or keep changing it since that could break in-flight orchestrations so if it gets added we'll do it when the right amount of time can be dedicated to it rather than rushing it out.