### PR TITLE
Updates to misc documents and the version for rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] (pre-release for 1.0)
+* Fix typo in CONTRIBUTORS
+  [#5](https://github.com/doximity/simplekiq/pull/5)
+* Fix incorrectly named spec file
+  [#9](https://github.com/doximity/simplekiq/pull/9)
+* README fix
+  [#10](https://github.com/doximity/simplekiq/pull/10)
+* Updating CONTRIBUTING license
+  [#16](https://github.com/doximity/simplekiq/pull/16)
+* Fix CHANGELOG typo
+  [#18](https://github.com/doximity/simplekiq/pull/18)
+* Add sidekiq-pro as an explicit dependency and loosen sidekiq requirements
+  [#19](https://github.com/doximity/simplekiq/pull/19)
+* Add new toplevel batch to encapsulate all batches within an orchestration
+  [#21](https://github.com/doximity/simplekiq/pull/21)
+* Fix bug with toplevel batch and include batch descriptions
+  [#23](https://github.com/doximity/simplekiq/pull/23)
+
 ## [0.0.3]
 * Misc minimal fixes to get the gem building and releasable according to our open source standards
   [#3](https://github.com/doximity/simplekiq/pull/3)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,22 +1,29 @@
 ## List of All Known Code Contributors to Simplekiq
 
-### Jack Noble
+### Jack Noble (Doximity)
 * Collaborated on initial concept
 * Wrote the majority of the code as of initial release
+* Helpful contributions to maintenance of specs, README, etc
 
-### John Wilkinson
+### John Wilkinson (Doximity)
 * Collaborated on initial concept
 * Conducted the gem extraction and release
 
-### Brian Dillard
+### Jason Hagglund (Doximity)
+* Finagled a way into getting us the ability to specify `sidekiq-pro` as an explicit dependency despite it not being publicly available and without exposing it to the public in the process.
+
+### Brian Dillard (Doximity)
 * Added additional comment documentation
 * Added support for `on_complete` batch callback support in `Simplekiq::BatchingJob`
 
-### Austen Madden
+### Austen Madden (Doximity)
 * Fixed bug with batch statuses in callbacks for empty batches
 
-### Tiffany Troha
+### Tiffany Troha (Doximity)
 * Added support for specifying `sidekiq_options` for the child job in `Simplekiq::BatchingJob`
 
 ### [Daniel Pepper](https://github.com/dpep)
 * On request, graciously took down his unused `simplekiq` placeholder from rubygems so we could continue using the name :raised_hands:
+
+### [Jeremy Smith](https://github.com/jeremysmithco)
+* Helpfully and respectfully nudged us towards loosening our sidekiq version requirement

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source "https://rubygems.org"
 
 source "https://enterprise.contribsys.com/" do
-  gem "sidekiq-ent"
-  gem "sidekiq-pro"
+  gem "sidekiq-pro", "5.2.1"
 end
+
+gem "sidekiq", "6.1.0"
 
 # Specify your gem's dependencies in simplekiq.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simplekiq (0.0.3)
+    simplekiq (0.1.0)
       sidekiq (>= 5.2.9)
       sidekiq-pro (~> 5.0)
 
@@ -11,10 +11,8 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
-    einhorn (0.7.4)
     method_source (1.0.0)
     parallel (1.22.1)
     parser (3.1.2.0)
@@ -22,12 +20,10 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rack (2.2.3)
-    rack-protection (2.2.0)
-      rack
+    rack (2.2.4)
     rainbow (3.1.1)
     rake (12.3.3)
-    redis (4.5.1)
+    redis (4.7.1)
     regexp_parser (2.3.1)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -60,18 +56,13 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    sidekiq (5.2.10)
-      connection_pool (~> 2.2, >= 2.2.2)
+    sidekiq (6.1.0)
+      connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (~> 4.5, < 4.6.0)
-    sidekiq-ent (1.8.1)
-      einhorn (= 0.7.4)
-      sidekiq (>= 5.2.3)
-      sidekiq-pro (>= 4.0.4)
-    sidekiq-pro (5.0.0)
-      concurrent-ruby (>= 1.0.5)
-      sidekiq (>= 5.2.7)
+      redis (>= 4.2.0)
+    sidekiq-pro (5.2.1)
+      connection_pool (>= 2.2.3)
+      sidekiq (>= 6.1.0)
     standard (1.11.0)
       rubocop (= 1.28.2)
       rubocop-performance (= 1.13.3)
@@ -85,8 +76,8 @@ DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.2)
   rspec_junit_formatter
-  sidekiq-ent!
-  sidekiq-pro!
+  sidekiq (= 6.1.0)
+  sidekiq-pro (= 5.2.1)!
   simplekiq!
   standard
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this line to your application's Gemfile:
 gem "simplekiq"
 ```
 
-Note that this gem requires you be a Sidekiq Pro paid subscriber to be able to use it, so after following the installation docs for getting the private gem configured with your system, ensure you have `sidekiq-pro` at version `~> 5.0.0` or higher and that it's being required:
+Note that this gem requires you be a Sidekiq Pro paid subscriber to be able to use it, so after following the installation docs for getting the private gem configured with your system, ensure you have `sidekiq-pro` at version `~> 5.0.0` or higher (need at least version `5.2.1` if you want to capture `on_death` callbacks [percolating up to parent batches](https://github.com/mperham/sidekiq/blob/main/Pro-Changes.md#521) - a supported feature which is not required for typical orchestration behavior) and that it's being required:
 
 ```ruby
 gem "sidekiq-pro", "~> 5.0.0"
@@ -82,7 +82,7 @@ Let's use the above example to describe some specifics of how the flow works.
 2. It does some initial work in `SomeInitialSetupJob`, which blocks the rest of the workflow until it completes successfully.
 3. Then it will run a `SomeParallelizableJob` for each of some number of associated models `some_related_models`. These jobs will all run parallel to each other independently.
 4. Finally, after all of the parallel jobs from #3 complete successfully, `SomeFinalizationJob` will run and then after it finishes the orchestration will be complete.
-5. If it ran into an error at some point, `on_death` will get fired with the first failure.
+5. If it ran into an error at some point, `on_death` will get fired with the first failure. (please use `sidekiq-pro` of at least `5.2.1` for this feature)
 6. It will call `on_complete` at the end of the orchestration no matter what, this is the place to collect all the failures and persist them somewhere.
 
 **Note** - it's fine to add utility methods and `attr_accessor`s to keep the code tidy and maintainable.
@@ -117,17 +117,19 @@ The crux of the problem was that each job was highly coupled to its position in 
 
 ## Versioning
 
-This project follows semantic versioning. At time of writing it is sitting at 0.0.1 until its integration with the application it was extracted from is confirmed to be stable. Once confirmed it will be started off at 1.0.0 as it has otherwise been used in a production system already for some time.
+This project follows semantic versioning. See https://semver.org/ for details.
 
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Note that this depends on `sidekiq-pro` which requires a [commercial license](https://sidekiq.org/products/pro.html) to install and use.
 
-Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Then, run `rake ci:specs` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
 
-TODO: Update this section with more specific/appropriate instructions once this is a public repository.
+To get a new release cut, please either open a PR or an issue with your ask with as much context as possible and someone from Doximity will consider your request. If it makes sense for the direction of the project we'll get it done and inform you of when a release has been made available with the changes.
+
+For internal employees: consult the company wiki on the current standard process for conducting releases for our public gems.
 
 ## Contributing
 

--- a/lib/simplekiq/version.rb
+++ b/lib/simplekiq/version.rb
@@ -1,3 +1,3 @@
 module Simplekiq
-  VERSION = "0.0.3"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Getting all the ducks in a row for the 1.0 release. This sets it up to be released as `0.1.0` so we can test it out in production for a bit before publicly re-releasing as `1.0.0`.

I also included some documentation updates to get things as they should be for the formal 1.0 release. Once this version is confirmed to be stable in production I'll do one more PR to change the version to `1.0.0` and will publish that version as well.