### PR TITLE
Update all circleci redis to 6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
       - image: cimg/ruby:2.6
         environment:
           BUNDLE_VERSION: "~> 2.1.4"
-      - image: redis:4-alpine
+      - image: redis:6.2
         command: redis-server
 
 # yaml anchor filters


### PR DESCRIPTION
Update circleci redis to match the version we use in production

[_Created by Sourcegraph batch change `btbam/redis-version-update-6.2`._](https://sourcegraph.build.dox.pub/users/btbam/batch-changes/redis-version-update-6.2)