### PR TITLE
Remove Branch Filters from CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,26 +12,6 @@ executors:
       - image: redis:6.2
         command: redis-server
 
-# yaml anchor filters
-always_run: &always_run
-  filters:
-    branches:
-      only: /.*/
-    tags:
-      only: /^v.*/
-pr_only: &pr_only
-  filters:
-    branches:
-      ignore: master
-    tags:
-      ignore: /.*/
-version_tags_only: &version_tags_only
-  filters:
-    branches:
-      ignore: /.*/
-    tags:
-      only: /^v.*/
-
 jobs:
   build:
     executor: ruby-with-redis
@@ -63,8 +43,7 @@ jobs:
 workflows:
   main:
     jobs:
-      - build:
-          <<: *always_run
+      - build:          
           context:
             - sidekiq-enterprise
             - nexus_readonly


### PR DESCRIPTION
https://doximity.slack.com/archives/C0LK9CT0E/p1762811889380619?thread_ts=1762482990.555769&cid=C0LK9CT0E

Make life simple - it's one CI job that should run on PR branches and `master` upon PR merge while ignoring tags, which is the CircleCI default behavior.