### PR TITLE
✨ Add optional `description` parameter to `#run` and `#in_parallel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+* Add a new parameter for descriptions to `#run` and `#in_parallel`
+  [#43](https://github.com/doximity/simplekiq/pull/44)
+
 ## [1.0.0]
 * Only support Sidekiq 7.1 and Sidekiq 8 (dropped support for older versions)
   [#42](https://github.com/doximity/simplekiq/pull/42)

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -23,20 +23,18 @@ module Simplekiq
 
     def serialized_workflow
       @serialized_workflow ||= serial_workflow.map do |item|
-        if item[:parallel]
+        result = if item[:parallel]
           jobs = item[:parallel].map do |entry|
             job, *args = entry[:step]
             {"klass" => job.name, "args" => args}
           end
-          result = {"jobs" => jobs}
-          result["description"] = item[:description] if item[:description]
-          result
+          {"jobs" => jobs}
         else
           job, *args = item[:step]
-          result = {"klass" => job.name, "args" => args}
-          result["description"] = item[:description] if item[:description]
-          result
+          {"klass" => job.name, "args" => args}
         end
+        result["description"] = item[:description] if item[:description]
+        result
       end
     end
   end

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -7,30 +7,35 @@ module Simplekiq
       @serial_workflow = []
     end
 
-    def run(*step)
+    def run(*step, description: nil)
       workflow = parallel_workflow || serial_workflow
-      workflow << step
+      workflow << {step: step, description: description}
     end
 
-    def in_parallel
+    def in_parallel(description: nil)
       @parallel_workflow = []
       yield
-      serial_workflow << @parallel_workflow if @parallel_workflow.any?
+      serial_workflow << {parallel: @parallel_workflow, description: description} if @parallel_workflow.any?
     ensure
       @parallel_workflow = nil
       serial_workflow
     end
 
     def serialized_workflow
-      @serialized_workflow ||= serial_workflow.map do |step|
-        case step[0]
-        when Array
-          step.map do |(job, *args)|
+      @serialized_workflow ||= serial_workflow.map do |item|
+        if item[:parallel]
+          jobs = item[:parallel].map do |entry|
+            job, *args = entry[:step]
             {"klass" => job.name, "args" => args}
           end
-        when Class
-          job, *args = step
-          {"klass" => job.name, "args" => args}
+          result = {"jobs" => jobs}
+          result["description"] = item[:description] if item[:description]
+          result
+        else
+          job, *args = item[:step]
+          result = {"klass" => job.name, "args" => args}
+          result["description"] = item[:description] if item[:description]
+          result
         end
       end
     end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -15,13 +15,20 @@ module Simplekiq
     end
 
     def run_step(workflow, step)
-      *jobs = workflow.at(step)
+      current = workflow.at(step)
+      next_step = step + 1
+
       # This will never be empty because Orchestration#serialized_workflow skips inserting
       # a new step for in_parallel if there were no inner jobs specified.
+      jobs = current["jobs"] || [current]
+      description = if current["description"]
+        current["description"]
+      else
+        "Simplekiq orchestrated step #{next_step}"
+      end
 
-      next_step = step + 1
       step_batch = Sidekiq::Batch.new
-      step_batch.description = "Simplekiq orchestrated step #{next_step}"
+      step_batch.description = description
       step_batch.on(
         "success",
         self.class,

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -21,11 +21,7 @@ module Simplekiq
       # This will never be empty because Orchestration#serialized_workflow skips inserting
       # a new step for in_parallel if there were no inner jobs specified.
       jobs = current["jobs"] || [current]
-      description = if current["description"]
-        current["description"]
-      else
-        "Simplekiq orchestrated step #{next_step}"
-      end
+      description = current["description"] || "Simplekiq orchestrated step #{next_step}"
 
       step_batch = Sidekiq::Batch.new
       step_batch.description = description

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -89,5 +89,27 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
 
       instance.run_step(workflow, 0)
     end
+
+    context "when a workflow has a description" do
+      let(:workflow) do
+        [
+          {"description" => "Some description", "klass" => "OrcTest::JobA", "args" => [1]}
+        ]
+      end
+      
+      it "sets the description of the step batch" do
+        allow(step_batch).to receive(:jobs) { |&block| block.call }
+        allow(OrcTest::JobA).to receive(:perform_async)
+        allow(Sidekiq::Batch).to receive(:new).and_return(step_batch)
+
+        expect(step_batch).to receive(:on).with("success", described_class, {
+          "orchestration_workflow" => workflow,
+          "step" => 1,
+        })
+        expect(step_batch).to receive(:description=).with("Some description")
+
+        instance.run_step(workflow, 0)
+      end
+    end
   end
 end

--- a/spec/orchestration_job_spec.rb
+++ b/spec/orchestration_job_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe Simplekiq::OrchestrationJob do
         job: job,
         workflow: [
           {"klass" => "OrcTest::JobA", "args" => ["some"]},
-          [
+          {"jobs" => [
             {"klass" => "OrcTest::JobB", "args" => ["some"]},
             {"klass" => "OrcTest::JobC", "args" => ["args"]}
-          ]
+          ]}
         ]
       )
 

--- a/spec/orchestration_spec.rb
+++ b/spec/orchestration_spec.rb
@@ -8,6 +8,34 @@ RSpec.describe Simplekiq::Orchestration do
     stub_const("OrcTest::JobB", Class.new)
   end
 
+  describe "run" do
+    subject { orchestration.serialized_workflow }
+
+    context "when run is called without a description" do
+      before do
+        orchestration.run OrcTest::JobA, "syn"
+      end
+
+      it "adds a step" do
+        expect(subject).to eq ([
+          {"klass" => "OrcTest::JobA", "args" => ["syn"]}
+        ])
+      end
+    end
+
+    context "when run is called with a description" do
+      before do
+        orchestration.run OrcTest::JobA, "syn", description: "Some description"
+      end
+
+      it "adds a step" do
+        expect(subject).to eq [
+          {"description" => "Some description", "klass" => "OrcTest::JobA", "args" => ["syn"]}
+        ]
+      end
+    end
+  end
+
   describe "in_parallel" do
     subject { orchestration.serialized_workflow }
 
@@ -24,20 +52,45 @@ RSpec.describe Simplekiq::Orchestration do
     end
 
     context "when in_parallel is called with run steps" do
-      before do
-        orchestration.in_parallel do
-          orchestration.run OrcTest::JobA, "syn"
-          orchestration.run OrcTest::JobB, "ack"
+      context "when the description is not provided" do
+        before do
+          orchestration.in_parallel do
+            orchestration.run OrcTest::JobA, "syn"
+            orchestration.run OrcTest::JobB, "ack"
+          end
+        end
+
+        it "adds a step" do
+          expect(subject).to eq [
+            {
+              "jobs" => [
+                {"klass" => "OrcTest::JobA", "args" => ["syn"]},
+                {"klass" => "OrcTest::JobB", "args" => ["ack"]}
+              ]
+            }
+          ]
         end
       end
 
-      it "adds a step" do
-        expect(subject).to eq [
-          [
-            {"klass" => "OrcTest::JobA", "args" => ["syn"]},
-            {"klass" => "OrcTest::JobB", "args" => ["ack"]}
-          ]
-        ]
+      context "when the description is provided" do
+        before do
+          orchestration.in_parallel(description: "Some description") do
+            orchestration.run OrcTest::JobA, "syn"
+            orchestration.run OrcTest::JobB, "ack"
+          end
+        end
+
+        it "adds a step with the description" do
+          expect(subject).to eq ([
+            {
+              "description" => "Some description",
+              "jobs" => [
+                {"klass" => "OrcTest::JobA", "args" => ["syn"]},
+                {"klass" => "OrcTest::JobB", "args" => ["ack"]},
+              ],
+            }
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
When adding jobs to our orchestration, we've had difficulty understanding which part of the flow we're on. Our workflow is long and we thought it would be nice to be able to add more descriptions to the steps.

This adds an optional description parameter and also adds a few tests alongside that. Would love any opinions and appreciate the contribution to the community for this gem.