### PR TITLE
Allow batching job to inherit from parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+* `Simplekiq::BatchingJob`-generated batch classes (`<Job>::SimplekiqBatch`) now
+  inherit from the including job's own superclass instead of a dedicated
+  `Simplekiq::BaseBatch` class, so they automatically pick up whatever that
+  superclass provides (retry defaults, logging hooks, kill switches, etc.) the
+  same way any other subclass would.
+  **Behavior change:** batch classes that never call `batch_sidekiq_options`
+  used to fall back to Sidekiq's global default options; they now fall back to
+  whatever Sidekiq options the job's superclass configures instead. Explicit
+  `batch_sidekiq_options` calls are unaffected and still take precedence. The
+  including job's *own* per-class `sidekiq_options` overrides are still not
+  inherited by the batch class (this was already true before this change),
+  since the batch class is a sibling of the job, not a subclass of it.
+
 ## [1.0.0]
 * Only support Sidekiq 7.1 and Sidekiq 8 (dropped support for older versions)
   [#42](https://github.com/doximity/simplekiq/pull/42)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@
 
 ### Lucas Lazzaris (Doximity)
 * Added support for sidekiq 7.x
+* Allowed `Simplekiq::BatchingJob` to be used as a mixin instead of a superclass, allowing it to be used with other job classes that already inherit from a different superclass (e.g., `ApplicationJob` in Rails)
 
 ### [Daniel Pepper](https://github.com/dpep)
 * On request, graciously took down his unused `simplekiq` placeholder from rubygems so we could continue using the name :raised_hands:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simplekiq (0.2.0)
+    simplekiq (1.1.0)
       sidekiq (>= 7.1, < 9.0)
       sidekiq-pro (>= 7.1, < 9.0)
 

--- a/lib/simplekiq/batching_job.rb
+++ b/lib/simplekiq/batching_job.rb
@@ -67,7 +67,10 @@ module Simplekiq
 
     class << self
       def included(klass)
-        batch_job_class = Class.new(BaseBatch)
+        batch_job_class = Class.new(klass.superclass) do
+          include BaseBatch
+          include Sidekiq::Job
+        end
         klass.const_set(BATCH_CLASS_NAME, batch_job_class)
 
         klass.extend ClassMethods
@@ -132,9 +135,7 @@ module Simplekiq
     end
   end
 
-  class BaseBatch
-    include Sidekiq::Job
-
+  module BaseBatch
     def perform(*args)
       module_parent_of_class.new.perform_batch(*args)
     end

--- a/lib/simplekiq/version.rb
+++ b/lib/simplekiq/version.rb
@@ -1,3 +1,3 @@
 module Simplekiq
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/batching_job_spec.rb
+++ b/spec/batching_job_spec.rb
@@ -153,6 +153,68 @@ RSpec.describe Simplekiq::BatchingJob do
     end
   end
 
+  describe "the generated batch class" do
+    let(:job_superclass) do
+      Class.new do
+        include Sidekiq::Job
+
+        def self.marker = "inherited from job superclass"
+      end
+    end
+
+    let(:test_job) do
+      Class.new(job_superclass) do
+        include Simplekiq::BatchingJob
+
+        def perform_batching(arg)
+          queue_batch(arg)
+        end
+
+        def perform_batch(arg)
+        end
+      end
+    end
+
+    before do
+      stub_const("TestJob", test_job)
+    end
+
+    it "inherits from the including job's own superclass, not a gem-owned base class" do
+      expect(TestJob::SimplekiqBatch.superclass).to eq(job_superclass)
+      expect(TestJob::SimplekiqBatch.marker).to eq("inherited from job superclass")
+    end
+
+    it "still performs batches via perform_batch" do
+      stub_const("Output", output = double("Output", call: nil))
+      test_job.define_method(:perform_batch) { |arg| Output.call(arg) }
+
+      test_job.new.perform("test")
+
+      expect(output).to have_received(:call).with("test")
+    end
+
+    context "when the job has no explicit superclass" do
+      let(:test_job) do
+        Class.new do
+          include Simplekiq::BatchingJob
+
+          def perform_batching(arg)
+            queue_batch(arg)
+          end
+
+          def perform_batch(arg)
+          end
+        end
+      end
+
+      it "falls back to Object" do
+        stub_const("TestJob", test_job)
+
+        expect(TestJob::SimplekiqBatch.superclass).to eq(Object)
+      end
+    end
+  end
+
   describe "batch_sidekiq_options" do
     let(:test_job) do
       Class.new do


### PR DESCRIPTION
### User Story

As an engineer using `Simplekiq::BatchingJob` (e.g. campaigns) I want their batch sub-jobs to automatically inherit whatever behavior the including job's own base class provides -- retry defaults, logging hooks, kill switches, etc. -- the same way any other subclass of that base class would, without having to duplicate that configuration via `batch_sidekiq_options`.

### High-Level Context

`Simplekiq::BatchingJob` generates a `<Job>::SimplekiqBatch` class to run each batch. That class used to always inherit from a dedicated `Simplekiq::BaseBatch` class, which only included `Sidekiq::Job` -- so batch classes never picked up anything from the including job's own base class.

This PR roots the generated batch class in the including job's own superclass instead (`Class.new(klass.superclass)`), and moves the batch class's `#perform` behavior into a `BaseBatch` module that's mixed into that dynamically-rooted class. The batch class now inherits retry defaults, logging hooks, and other superclass-provided behavior automatically, just like a normal subclass would.

**Behavior change:** batch classes that never call `batch_sidekiq_options` used to fall back to Sidekiq's global default options; they now fall back to whatever Sidekiq options the job's superclass configures instead. Explicit `batch_sidekiq_options` calls are unaffected and still take precedence. The including job's *own* per-class `sidekiq_options` overrides are still not inherited by the batch class (this was already true before this change), since the batch class is a sibling of the job, not a subclass of it.

Version bumped to 1.1.0 and CHANGELOG updated with the same details.